### PR TITLE
generic seeds.sql added to aid in testing, see comment

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE role (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(30) NOT NULL,
     salary DECIMAL(15, 2) NOT NULL,
-    department_id INT NOT NULL,
+    department_id INT,
     FOREIGN KEY (department_id) REFERENCES department(id) ON DELETE SET NULL
 );
 
@@ -23,7 +23,7 @@ CREATE TABLE employee (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     first_name VARCHAR(30) NOT NULL,
     last_name VARCHAR(30) NOT NULL,
-    role_id INT NOT NULL,
+    role_id INT,
     -- Don't forget, the following will link to the manager of this employee, can be null if they have no manager
     manager_id INT,
     FOREIGN KEY (role_id) REFERENCES role(id) ON DELETE SET NULL,
@@ -31,4 +31,4 @@ CREATE TABLE employee (
 );
 
 -- Using this for quick testing/debugging purposes
-SELECT * FROM department;
+SHOW TABLES;

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,0 +1,28 @@
+-- Setting up generic seed info to aid in more visual testing
+INSERT INTO department (name)
+VALUES ("History"),
+       ("Math"),
+       ("Science"),
+       ("English"),
+       ("Art"),
+       ("Game Design"),
+       ("Business");
+
+INSERT INTO role (title, salary, department_id)
+VALUES ("Instructor", 60000, 1),
+       ("TA", 40000, 3),
+       ("SSA", 30000, 6),
+       ("Advisor", 35000, 7);
+
+INSERT INTO employee (first_name, last_name, role_id, manager_id)
+VALUES ("D", "B", 1, NULL),
+       ("R", "B", 2, NULL),
+       ("N", "H", 4, NULL),
+       ("M", "L", 3, NULL),
+       ("D", "K", 4, NULL),
+       ("A", "J", 4, NULL);
+
+-- Using this for quick testing/debugging purposes
+SELECT * FROM department;
+SELECT * FROM role;
+SELECT * FROM employee;


### PR DESCRIPTION
Basic seeds.sql info added to help visualize tests and debugging. New issue arose: problems start when manager_id is entered for new employees instead of NULL. Must look into that further. Suspect issue with having a primary key related to a foreign key within the same table.